### PR TITLE
feat: create transport

### DIFF
--- a/packages/api/spec/predictivemovement.yaml
+++ b/packages/api/spec/predictivemovement.yaml
@@ -42,6 +42,9 @@ paths:
                       type: number
                     weight:
                       type: number
+                  required: 
+                    - volume
+                    - weight
                 earliest_start:
                   type: string
                   # format: date-time
@@ -57,6 +60,7 @@ paths:
               required: 
                 - start_address
                 - end_address
+                - capacity
             examples:
               standard_transport:
                 value:
@@ -76,6 +80,9 @@ paths:
                       position:
                         lon: 17.958416
                         lat: 59.215666
+                  capacity: 
+                    volume: 34
+                    weight: 4
       responses:
         "201":
           description: Created

--- a/packages/api/spec/predictivemovement.yaml
+++ b/packages/api/spec/predictivemovement.yaml
@@ -25,6 +25,65 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Transport"
+    post:
+      operationId: "create_transport"
+      summary: Create a new transport
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                capacity:
+                  type: object
+                  properties:
+                    volume:
+                      type: number
+                    weight:
+                      type: number
+                earliest_start:
+                  type: string
+                  # format: date-time
+                latest_end:
+                  type: string
+                  # format: date-time
+                metadata:
+                  $ref: "#/components/schemas/AnyValue"
+                start_address:
+                  $ref: "#/components/schemas/Address"
+                end_address:
+                  $ref: "#/components/schemas/Address"
+              required: 
+                - start_address
+                - end_address
+            examples:
+              standard_transport:
+                value:
+                  start_address:
+                    address:
+                      city: "Stockholm"
+                      street: "Visättra Backe 6"
+                      name: "Visättra backe 6, Stockholm"
+                      position:
+                        lon: 17.958416
+                        lat: 59.215666
+                  end_address:
+                    address:
+                      city: "Stockholm"
+                      street: "Visättra Backe 6"
+                      name: "Visättra backe 6, Stockholm"
+                      position:
+                        lon: 17.958416
+                        lat: 59.215666
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: "#/components/schemas/Transport"
+
   /itinerary/{transport_id}:
     get:
       operationId: get_itinerary
@@ -43,7 +102,7 @@ paths:
           content:
             application/json; charset=utf-8:
               schema:
-                $ref: "#/components/schemas/Itinerary"
+                $ref: "#/components/schemas/Itinerary" 
   /bookings:
     post:
       operationId: "create_booking"
@@ -184,7 +243,7 @@ components:
     Transport:
       type: object
       properties:
-        transport_id:
+        id:
           type: string
         busy:
           type: boolean

--- a/packages/api/spec/predictivemovement.yaml
+++ b/packages/api/spec/predictivemovement.yaml
@@ -51,8 +51,6 @@ paths:
                 latest_end:
                   type: string
                   # format: date-time
-                metadata:
-                  $ref: "#/components/schemas/AnyValue"
                 start_address:
                   $ref: "#/components/schemas/Address"
                 end_address:
@@ -65,21 +63,19 @@ paths:
               standard_transport:
                 value:
                   start_address:
-                    address:
                       city: "Stockholm"
                       street: "Visättra Backe 6"
                       name: "Visättra backe 6, Stockholm"
                       position:
                         lon: 17.958416
                         lat: 59.215666
-                  end_address:
-                    address:
-                      city: "Stockholm"
-                      street: "Visättra Backe 6"
-                      name: "Visättra backe 6, Stockholm"
-                      position:
-                        lon: 17.958416
-                        lat: 59.215666
+                  end_address:     
+                    city: "Stockholm"
+                    street: "Visättra Backe 6"
+                    name: "Visättra backe 6, Stockholm"
+                    position:
+                      lon: 17.958416
+                      lat: 59.215666
                   capacity: 
                     volume: 34
                     weight: 4
@@ -252,8 +248,6 @@ components:
       properties:
         id:
           type: string
-        busy:
-          type: boolean
         capacity:
           type: object
           properties:
@@ -264,11 +258,9 @@ components:
         earliest_start:
           type: string
           # format: date-time
-        latest_end:
+        latest_end: 
           type: string
           # format: date-time
-        metadata:
-          type: object
         start_address:
           $ref: "#/components/schemas/Address"
         end_address:

--- a/packages/api/src/__generated__/schema.ts
+++ b/packages/api/src/__generated__/schema.ts
@@ -6,6 +6,7 @@
 export interface paths {
   "/transports": {
     get: operations["get_transports"];
+    post: operations["create_transport"];
   };
   "/itinerary/{transport_id}": {
     get: operations["get_itinerary"];
@@ -38,7 +39,7 @@ export interface components {
       height?: number;
     };
     Transport: {
-      transport_id?: string;
+      id?: string;
       busy?: boolean;
       capacity?: {
         volume?: number;
@@ -95,6 +96,31 @@ export interface operations {
       200: {
         content: {
           "application/json; charset=utf-8": components["schemas"]["Transport"][];
+        };
+      };
+    };
+  };
+  create_transport: {
+    responses: {
+      /** Created */
+      201: {
+        content: {
+          "application/json; charset=utf-8": components["schemas"]["Transport"];
+        };
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          capacity?: {
+            volume?: number;
+            weight?: number;
+          };
+          earliest_start?: string;
+          latest_end?: string;
+          metadata?: components["schemas"]["AnyValue"];
+          start_address: components["schemas"]["Address"];
+          end_address: components["schemas"]["Address"];
         };
       };
     };

--- a/packages/api/src/__generated__/schema.ts
+++ b/packages/api/src/__generated__/schema.ts
@@ -112,9 +112,9 @@ export interface operations {
     requestBody: {
       content: {
         "application/json": {
-          capacity?: {
-            volume?: number;
-            weight?: number;
+          capacity: {
+            volume: number;
+            weight: number;
           };
           earliest_start?: string;
           latest_end?: string;

--- a/packages/api/src/__generated__/schema.ts
+++ b/packages/api/src/__generated__/schema.ts
@@ -40,14 +40,12 @@ export interface components {
     };
     Transport: {
       id?: string;
-      busy?: boolean;
       capacity?: {
         volume?: number;
         weight?: number;
       };
       earliest_start?: string;
       latest_end?: string;
-      metadata?: { [key: string]: any };
       start_address?: components["schemas"]["Address"];
       end_address?: components["schemas"]["Address"];
     };
@@ -118,7 +116,6 @@ export interface operations {
           };
           earliest_start?: string;
           latest_end?: string;
-          metadata?: components["schemas"]["AnyValue"];
           start_address: components["schemas"]["Address"];
           end_address: components["schemas"]["Address"];
         };

--- a/packages/api/src/__tests__/engineAdapter.test.ts
+++ b/packages/api/src/__tests__/engineAdapter.test.ts
@@ -1,5 +1,6 @@
-import { createBooking, CreateBookingInput } from '../engineAdapter'
-import { amqp } from '../rabbitmqConnector'
+import { createBooking, CreateBookingInput } from '../booking/engineAdapter'
+import { amqp } from '../amqp/connector'
+import { createTransport, CreateTransportInput } from '../transport/engineAdapter'
 describe('engine adapter', () => {
 
   afterAll(() => amqp.close())
@@ -19,6 +20,23 @@ describe('engine adapter', () => {
 
       const result = await createBooking(
         (bookingPayload as any) as CreateBookingInput
+      )
+      expect(result.id).toBeDefined()
+    })
+  })
+
+
+  describe('#createTransport()', () => {
+    it('generates an id and sends the transport payload to rabbit', async () => {
+      expect.assertions(1)
+      const transportPayload = {
+        start_address: {position:  {lat: 31.337, lon: 69.69 }},
+        end_address: {position: {lat: 1.337, lon: 6.9 } },
+        capacity: {volume: 2, weight: 4}
+      }
+
+      const result = await createTransport(
+        (transportPayload as any) as CreateTransportInput
       )
       expect(result.id).toBeDefined()
     })

--- a/packages/api/src/amqp/connector.ts
+++ b/packages/api/src/amqp/connector.ts
@@ -1,0 +1,4 @@
+const amqp = require('fluent-amqp')(process.env.AMQP_URL || 'amqp://localhost')
+amqp.connect()
+
+export {amqp}

--- a/packages/api/src/booking/engineAdapter.ts
+++ b/packages/api/src/booking/engineAdapter.ts
@@ -3,7 +3,7 @@ import {
   waitForBookingCreated,
   EngineBooking
 } from './rabbitmqConnector'
-import { operations, components } from './__generated__/schema'
+import { operations, components } from '../__generated__/schema'
 import { nanoid } from 'nanoid'
 
 export type CreateBookingInput = operations['create_booking']['requestBody']['content']['application/json']
@@ -56,5 +56,7 @@ const createBooking = async (input: CreateBookingInput): Promise<Booking> => {
   const answer = await waitForBookingCreated(id)
   return engineBookingToAPI(answer)
 }
+
+
 
 export { createBooking } 

--- a/packages/api/src/booking/rabbitmqConnector.ts
+++ b/packages/api/src/booking/rabbitmqConnector.ts
@@ -1,6 +1,6 @@
-export const amqp = require('fluent-amqp')(process.env.AMQP_URL || 'amqp://localhost')
+import {amqp} from '../amqp/connector'
 import EventEmitter from 'events'
-amqp.connect()
+
 export interface EngineBookingRequest {
   id: string,
   pickup: {

--- a/packages/api/src/routeHandlers.ts
+++ b/packages/api/src/routeHandlers.ts
@@ -6,7 +6,7 @@ import { operations } from './__generated__/schema'
 export const get_transports: Handler = (_c, _req, res) => {
   res.status(200).json([
     {
-      transport_id: '',
+      id: '',
       busy: false,
       capacity: {
         volume: 0,

--- a/packages/api/src/routeHandlers.ts
+++ b/packages/api/src/routeHandlers.ts
@@ -1,5 +1,6 @@
 import { Handler } from 'openapi-backend'
-import { createBooking } from './engineAdapter'
+import { createBooking } from './booking/engineAdapter'
+import { createTransport } from './transport/engineAdapter'
 import { operations } from './__generated__/schema'
 
 export const get_transports: Handler = (_c, _req, res) => {
@@ -61,4 +62,11 @@ export const create_booking: Handler = async (ctx, req, res) => {
   const requestBody: Body = ctx.request.requestBody
   const booking = await createBooking(requestBody)
   res.status(201).json(booking)
+}
+
+export const create_transport: Handler = async (ctx, req, res) => {
+  type Body = operations['create_transport']['requestBody']['content']['application/json']
+  const requestBody: Body = ctx.request.requestBody
+  const transport = await createTransport(requestBody)
+  res.status(201).json(transport)
 }

--- a/packages/api/src/transport/engineAdapter.ts
+++ b/packages/api/src/transport/engineAdapter.ts
@@ -10,21 +10,24 @@ export type CreateTransportInput = operations['create_transport']['requestBody']
 export type Transport = components['schemas']['Transport']
 
 function engineTransportToAPI(input: EngineTransportRequest): Transport {
+
   return {
     id: input.id,
-      start_address: {
-        position: input.start_address,
-        city: '',
-        street: '',
-        name: '',
-      },
-      end_address: {
-        position: input.end_address,
-        city: '',
-        street: '',
-        name: '',
-      },
-      capacity: input.capacity && {
+    earliest_start: input.earliest_start || '',
+    latest_end: input.latest_end || '',
+    start_address: {
+      position: input.start_address,
+      city: '',
+      street: '',
+      name: '',
+    },
+    end_address: {
+      position: input.end_address,
+      city: '',
+      street: '',
+      name: '',
+    },
+    capacity: input.capacity && {
       weight: input.capacity.weight || 0,
       volume: input.capacity.volume || 0
     },
@@ -41,13 +44,13 @@ const createTransport = async (input: CreateTransportInput): Promise<Transport> 
     end_address: {
       ...input.end_address.position,
     },
-    metadata: {},
     capacity: {
       ...input.capacity
     }
   })
 
   const answer = await waitForTransportCreated(id)
+
   return engineTransportToAPI(answer)
 }
 

--- a/packages/api/src/transport/engineAdapter.ts
+++ b/packages/api/src/transport/engineAdapter.ts
@@ -1,0 +1,52 @@
+import {
+  EngineTransportRequest,
+  publishCreateTransport,
+  waitForTransportCreated,
+} from './rabbitmqConnector'
+import { operations, components } from '../__generated__/schema'
+import { nanoid } from 'nanoid'
+
+export type CreateTransportInput = operations['create_transport']['requestBody']['content']['application/json']
+export type Transport = components['schemas']['Transport']
+
+function engineTransportToAPI(input: EngineTransportRequest): Transport {
+  return {
+    id: input.id,
+      start_address: {
+        position: input.start_address,
+        city: '',
+        street: '',
+        name: '',
+      },
+      end_address: {
+        position: input.end_address,
+        city: '',
+        street: '',
+        name: '',
+      },
+      capacity: input.capacity && {
+      weight: input.capacity.weight || 0,
+      volume: input.capacity.volume || 0
+    },
+  }
+}
+
+const createTransport = async (input: CreateTransportInput): Promise<Transport> => {
+  const id = `pmv-${nanoid(8)}`
+  await publishCreateTransport({
+    id,
+    start_address: {
+      ...input.start_address.position,
+    },
+    end_address: {
+      ...input.end_address.position,
+    },
+    metadata: {},
+    capacity: {}
+  })
+
+  const answer = await waitForTransportCreated(id)
+  return engineTransportToAPI(answer)
+}
+
+export { createTransport } 

--- a/packages/api/src/transport/engineAdapter.ts
+++ b/packages/api/src/transport/engineAdapter.ts
@@ -32,7 +32,7 @@ function engineTransportToAPI(input: EngineTransportRequest): Transport {
 }
 
 const createTransport = async (input: CreateTransportInput): Promise<Transport> => {
-  const id = `pmv-${nanoid(8)}`
+  const id = `pmt-${nanoid(8)}`
   await publishCreateTransport({
     id,
     start_address: {
@@ -42,7 +42,9 @@ const createTransport = async (input: CreateTransportInput): Promise<Transport> 
       ...input.end_address.position,
     },
     metadata: {},
-    capacity: {}
+    capacity: {
+      ...input.capacity
+    }
   })
 
   const answer = await waitForTransportCreated(id)

--- a/packages/api/src/transport/rabbitmqConnector.ts
+++ b/packages/api/src/transport/rabbitmqConnector.ts
@@ -1,0 +1,65 @@
+import {amqp} from '../amqp/connector'
+import EventEmitter from 'events'
+
+export interface EngineTransportRequest {
+  id: string,
+  start_address: {
+    lat: number,
+    lon: number
+  },
+  end_address: {
+    lat: number,
+    lon: number
+  },
+  metadata: {},
+  capacity: {
+    weight?: number,
+    volume?: number
+  },
+}
+
+const publishCreateTransport = (transport: EngineTransportRequest) => {
+  return amqp
+      .exchange('incoming_transport_updates', 'topic', { durable: true })
+      .publish(
+        {...transport},'registered',
+        {
+          persistent: true,
+        }
+      ).then(() =>
+      console.log(` [x] Created Transport '${JSON.stringify(transport, null, 2)}'`)
+    )
+}
+
+
+const emitter = new EventEmitter()
+
+amqp
+    .exchange('outgoing_transport_updates', 'topic', {
+      durable: true,
+    })
+    .queue('transport_notifications.api', {
+      durable: true,
+    })
+    .subscribe({ noAck: true }, '*')
+    .map((res: any) => {
+      const json = res.json()
+      return [res.fields.routingKey, json]
+    })
+    .each(([routingKey, msg]: [string, Object]) => {
+      emitter.emit(routingKey, msg)
+    })
+
+function waitForTransportCreated(transportId: string): Promise<EngineTransportRequest> {
+  return new Promise((resolve, _reject) => {
+    function listener(transport: EngineTransportRequest) {
+        if (transport.id === transportId) {
+          resolve(transport)
+          emitter.removeListener('new', listener)
+        }
+      }
+    emitter.addListener('new', listener)
+  })
+}
+
+export { publishCreateTransport, waitForTransportCreated }

--- a/packages/api/src/transport/rabbitmqConnector.ts
+++ b/packages/api/src/transport/rabbitmqConnector.ts
@@ -2,7 +2,9 @@ import {amqp} from '../amqp/connector'
 import EventEmitter from 'events'
 
 export interface EngineTransportRequest {
-  id: string,
+  id:string
+  earliest_start?: string,
+  latest_end?: string,
   start_address: {
     lat: number,
     lon: number
@@ -11,7 +13,6 @@ export interface EngineTransportRequest {
     lat: number,
     lon: number
   },
-  metadata: {},
   capacity: {
     weight?: number,
     volume?: number

--- a/packages/driver-interface/src/adapters/amqp.ts
+++ b/packages/driver-interface/src/adapters/amqp.ts
@@ -36,8 +36,8 @@ function connectRabbit() {
 export const exchanges = {
   INCOMING_BOOKING_UPDATES: 'incoming_booking_updates',
   OUTGOING_BOOKING_UPDATES: 'outgoing_booking_updates',
-  INCOMING_VEHICLE_UPDATES: 'incoming_vehicle_updates',
-  OUTGOING_VEHICLE_UPDATES: 'outgoing_vehicle_updates',
+  INCOMING_VEHICLE_UPDATES: 'incoming_transport_updates',
+  OUTGOING_VEHICLE_UPDATES: 'outgoing_transport_updates',
   DELIVERY_RECEIPTS: 'delivery_receipts',
   FREIGHTSLIPS: 'freightslips',
 }

--- a/packages/engine-server/lib/engineConnector.js
+++ b/packages/engine-server/lib/engineConnector.js
@@ -67,7 +67,7 @@ module.exports = (io) => {
     })
 
   const transports = amqp
-    .exchange('outgoing_vehicle_updates', 'topic', {
+    .exchange('outgoing_transport_updates', 'topic', {
       durable: true,
     })
     .queue('update_vehicle_in_admin_ui', {
@@ -142,7 +142,7 @@ module.exports = (io) => {
   }
 
   const transportLocationUpdates = amqp
-    .exchange('incoming_vehicle_updates', 'topic', {
+    .exchange('incoming_transport_updates', 'topic', {
       durable: true,
     })
     .queue('update_location.admin_ui', {
@@ -152,7 +152,7 @@ module.exports = (io) => {
     .map((res) => res.json())
 
   amqp
-    .exchange('outgoing_vehicle_updates', 'topic', {
+    .exchange('outgoing_transport_updates', 'topic', {
       durable: true,
     })
     .queue('delete_vehicle_in_admin_ui', {
@@ -213,7 +213,7 @@ module.exports = (io) => {
 
   const createTransport = (transport) => {
     return amqp
-      .exchange('incoming_vehicle_updates', 'topic', { durable: true })
+      .exchange('incoming_transport_updates', 'topic', { durable: true })
       .publish(
         {
           id: id62(),
@@ -254,7 +254,7 @@ module.exports = (io) => {
 
   const publishDeleteTransport = (id) => {
     return amqp
-      .exchange('incoming_vehicle_updates', 'topic', {
+      .exchange('incoming_transport_updates', 'topic', {
         durable: true,
       })
       .publish(id, routingKeys.DELETED, {
@@ -264,7 +264,7 @@ module.exports = (io) => {
   }
 
   const transportEvents = amqp
-    .exchange('incoming_vehicle_updates', 'topic', { durable: true })
+    .exchange('incoming_transport_updates', 'topic', { durable: true })
     .queue('transport_notifications.admin_ui', { durable: true })
     .subscribe({ noAck: true }, [
       routingKeys.TRANSPORT.LOGIN,
@@ -279,7 +279,7 @@ module.exports = (io) => {
     })
 
   const transportNotifications = amqp
-    .exchange('outgoing_vehicle_updates', 'topic', {
+    .exchange('outgoing_transport_updates', 'topic', {
       durable: true,
     })
     .queue('transport_notifications.admin_ui', {
@@ -333,7 +333,7 @@ module.exports = (io) => {
   }
 
   const transportUpdates = amqp
-    .exchange('outgoing_vehicle_updates', 'topic', {
+    .exchange('outgoing_transport_updates', 'topic', {
       durable: true,
     })
     .queue('transport_updated', {
@@ -345,7 +345,7 @@ module.exports = (io) => {
 
   const publishUpdateTransport = (transport) => {
     return amqp
-      .exchange('incoming_vehicle_updates', 'topic', {
+      .exchange('incoming_transport_updates', 'topic', {
         durable: true,
       })
       .publish(transport, routingKeys.UPDATED, {

--- a/packages/engine-ui/src/types/index.ts
+++ b/packages/engine-ui/src/types/index.ts
@@ -83,7 +83,6 @@ export type InAppColor = string
 export type Transport = {
   activities: Activity[] | null
   bookingIds: string[] | null
-  busy: any
   capacity?: Capacity
   color: InAppColor
   currentRoute: any
@@ -91,7 +90,6 @@ export type Transport = {
   endAddress: Address
   id: string
   latestEnd: Date
-  metadata: TransportMetadata
   startAddress: Address
 }
 
@@ -112,14 +110,12 @@ export interface Plan {
 export interface Route {
   activities: Activity[] | null
   bookingIds: string[] | null
-  busy: any
   capacity?: { weight?: number; volume?: number }
   currentRoute: any
   earliestStart: Date
   endAddress: Address
   id: string
   latestEnd: Date
-  metadata?: { profile?: string }
   startAddress: Address
 }
 

--- a/packages/engine_umbrella/apps/engine/lib/processors/booking_processor.ex
+++ b/packages/engine_umbrella/apps/engine/lib/processors/booking_processor.ex
@@ -76,7 +76,6 @@ defmodule Engine.BookingProcessor do
   defp string_to_vehicle_transform(vehicle_string) do
     vehicle_string
     |> Jason.decode!(keys: :atoms)
-    |> Map.delete(:id)
   end
 
   defp string_to_booking_transform(booking_string) do

--- a/packages/engine_umbrella/apps/engine/lib/vehicle.ex
+++ b/packages/engine_umbrella/apps/engine/lib/vehicle.ex
@@ -9,10 +9,8 @@ defmodule Vehicle do
 
   defstruct [
     :id,
-    :busy,
     :activities,
     :booking_ids,
-    :metadata,
     :start_address,
     :end_address,
     :earliest_start,
@@ -72,16 +70,8 @@ defmodule Vehicle do
       vehicle_info
       |> Map.put_new(:end_address, start_address)
       |> Map.put_new(:capacity, %{volume: 15, weight: 700})
-      |> Map.update(:metadata, nil, &Jason.encode!/1)
-
-    vehicle = struct(Vehicle, vehicle_fields)
-
-    with true <- Vex.valid?(vehicle) do
-      %VehicleRegistered{vehicle: vehicle}
-      |> ES.add_event()
-
-      apply_vehicle_to_state(vehicle)
-      vehicle_fields.id
+      |> Map.update(:metadata, nil, &Jason.encode!/1)const json = res.json()
+      return [res.fields.routingKey, json]
     else
       _ ->
         vehicle

--- a/packages/engine_umbrella/apps/engine/test/booking_processor_test.exs
+++ b/packages/engine_umbrella/apps/engine/test/booking_processor_test.exs
@@ -294,7 +294,6 @@ defmodule BookingProcessorTest do
     |> Booking.make()
 
     TransportGenerator.generate_transport_props(%{
-      id: "vehicle-1",
       start_address: %{
         lon: 21.92567,
         lat: 65.6335

--- a/packages/engine_umbrella/apps/engine/test/booking_updates_processor_test.exs
+++ b/packages/engine_umbrella/apps/engine/test/booking_updates_processor_test.exs
@@ -1,6 +1,7 @@
 defmodule BookingUpdatesProcessorTest do
   use ExUnit.Case
   alias MessageGenerator.BookingGenerator
+  alias MessageGenerator.Id
   import TestHelper
   import Mox
 
@@ -13,7 +14,11 @@ defmodule BookingUpdatesProcessorTest do
   end
 
   test "pickup update is registered" do
-    vehicle_id = Vehicle.make(%{start_address: %{lat: 61.80762475411504, lon: 16.05761905846783}})
+    vehicle_id =
+      Vehicle.make(%{
+        id: Id.generate_transport_id(),
+        start_address: %{lat: 61.80762475411504, lon: 16.05761905846783}
+      })
 
     booking_id =
       BookingGenerator.generate_booking_props(%{
@@ -46,7 +51,11 @@ defmodule BookingUpdatesProcessorTest do
   end
 
   test "delivered update is registered and published" do
-    vehicle_id = Vehicle.make(%{start_address: %{lat: 61.80762475411504, lon: 16.05761905846783}})
+    vehicle_id =
+      Vehicle.make(%{
+        id: Id.generate_transport_id(),
+        start_address: %{lat: 61.80762475411504, lon: 16.05761905846783}
+      })
 
     booking_id =
       BookingGenerator.generate_booking_props(%{

--- a/packages/engine_umbrella/apps/engine/test/plan_test.exs
+++ b/packages/engine_umbrella/apps/engine/test/plan_test.exs
@@ -129,14 +129,12 @@ defmodule PlanTest do
         %{
           activities: nil,
           booking_ids: nil,
-          busy: nil,
           capacity: %{volume: 18, weight: 50},
           current_route: nil,
           earliest_start: nil,
           end_address: %{lat: 61.840584, lon: 16.033552},
           id: "pmt-5MNjCOZb",
           latest_end: nil,
-          metadata: %{},
           profile: nil,
           start_address: %{lat: 61.840584, lon: 16.033552}
         }

--- a/packages/engine_umbrella/apps/engine/test/plan_test.exs
+++ b/packages/engine_umbrella/apps/engine/test/plan_test.exs
@@ -134,7 +134,7 @@ defmodule PlanTest do
           current_route: nil,
           earliest_start: nil,
           end_address: %{lat: 61.840584, lon: 16.033552},
-          id: "pmv-5MNjCOZb",
+          id: "pmt-5MNjCOZb",
           latest_end: nil,
           metadata: %{},
           profile: nil,

--- a/packages/engine_umbrella/apps/message_generator/lib/booking_generator.ex
+++ b/packages/engine_umbrella/apps/message_generator/lib/booking_generator.ex
@@ -1,28 +1,19 @@
 defmodule MessageGenerator.BookingGenerator do
   alias MessageGenerator.Address
+  alias MessageGenerator.Id
 
   @stockholm %{lat: 59.3414072, lon: 18.0470482}
   @gothenburg %{lat: 57.7009147, lon: 11.7537571}
   @ljusdal %{lat: 61.829182, lon: 16.0896213}
 
-    @default_metadata %{
+  @default_metadata %{
     sender: %{contact: "0701234567", name: "Anna Mottagaresson"},
     recipient: %{contact: "0707654321", name: "Mats Avsändaresson"}
   }
 
-  def generate_id do
-    alphabet = "abcdefghijklmnopqrstuvwxyz0123456789" |> String.split("", trim: true)
-
-    UUID.uuid4()
-    |> Base.encode64(padding: false)
-    |> String.replace(["+", "/"], Enum.random(alphabet))
-    |> String.slice(0, 8)
-    |> String.downcase()
-  end
-
   def generate_booking_props(properties \\ %{}) do
     properties
-    |> Map.put_new(:id, "pmb-" <> Engine.Utils.generate_id())
+    |> Map.put_new(:id, Id.generate_booking_id())
     |> Map.put_new(:external_id, Enum.random(0..100_000))
     |> put_new_booking_addresses_from_city(:ljusdal)
     |> Map.put_new(:size, %{measurements: [105, 55, 26], weight: Enum.random(1..200)})

--- a/packages/engine_umbrella/apps/message_generator/lib/generator.ex
+++ b/packages/engine_umbrella/apps/message_generator/lib/generator.ex
@@ -3,7 +3,7 @@ defmodule Generator do
   alias MessageGenerator.TransportGenerator
   alias MessageGenerator.BookingGenerator
 
-  @transports_exchange "incoming_vehicle_updates"
+  @transports_exchange "incoming_transport_updates"
   @bookings_exchange "incoming_booking_updates"
 
   def add_transport(properties \\ %{})

--- a/packages/engine_umbrella/apps/message_generator/lib/id_generator.ex
+++ b/packages/engine_umbrella/apps/message_generator/lib/id_generator.ex
@@ -1,0 +1,15 @@
+defmodule MessageGenerator.Id do
+  def generate_id do
+    alphabet = "abcdefghijklmnopqrstuvwxyz0123456789" |> String.split("", trim: true)
+
+    UUID.uuid4()
+    |> Base.encode64(padding: false)
+    |> String.replace(["+", "/"], Enum.random(alphabet))
+    |> String.slice(0, 8)
+    |> String.downcase()
+  end
+
+  def generate_booking_id, do: "pmb-" <> generate_id()
+
+  def generate_transport_id, do: "pmt-" <> generate_id()
+end

--- a/packages/engine_umbrella/apps/message_generator/lib/transport_generator.ex
+++ b/packages/engine_umbrella/apps/message_generator/lib/transport_generator.ex
@@ -1,5 +1,6 @@
 defmodule MessageGenerator.TransportGenerator do
   alias MessageGenerator.Address
+  alias MessageGenerator.Id
 
   @stockholm %{lat: 59.3414072, lon: 18.0470482}
   @gothenburg %{lat: 57.7009147, lon: 11.7537571}
@@ -8,7 +9,7 @@ defmodule MessageGenerator.TransportGenerator do
   defp default_metadata() do
     %{
       profile: "Generated transport #{Enum.random(1..100)}",
-      driver: %{ contact: "4676000#{Enum.random(1000..9999)}"}
+      driver: %{contact: "4676000#{Enum.random(1000..9999)}"}
     }
   end
 
@@ -16,6 +17,7 @@ defmodule MessageGenerator.TransportGenerator do
     default_meta = default_metadata()
 
     properties
+    |> Map.put_new(:id, Id.generate_transport_id())
     |> put_new_transport_addresses_from_city(:ljusdal)
     |> Map.update(:metadata, default_meta, &Map.merge(default_meta, &1))
   end

--- a/packages/engine_umbrella/config/config.exs
+++ b/packages/engine_umbrella/config/config.exs
@@ -3,8 +3,8 @@ import Config
 config :engine, Adapters.RMQ, Engine.Adapters.RMQ
 config :engine, :rmq_producer, BroadwayRabbitMQ.Producer
 
-config :engine, :outgoing_vehicle_exchange, "outgoing_vehicle_updates"
-config :engine, :incoming_vehicle_exchange, "incoming_vehicle_updates"
+config :engine, :outgoing_vehicle_exchange, "outgoing_transport_updates"
+config :engine, :incoming_vehicle_exchange, "incoming_transport_updates"
 config :engine, :outgoing_booking_exchange, "outgoing_booking_updates"
 config :engine, :incoming_booking_exchange, "incoming_booking_updates"
 config :engine, :outgoing_plan_exchange, "outgoing_plan_updates"


### PR DESCRIPTION
Create new route for creating transport 

Removed properties `busy` and `metadata` for now. When/if we need it in the future we could just add it again. 