### PR TITLE
chore: Setup api live

### DIFF
--- a/k8s/base/dependencies/kustomization.yaml
+++ b/k8s/base/dependencies/kustomization.yaml
@@ -6,9 +6,9 @@ kind: Kustomization
 resources:
   - postgres.yaml
   - rabbitmq.yaml
-  - redis.yaml
-  - minio.yaml
-  - postgres-backup.yaml
+  # - redis.yaml
+  # - minio.yaml
+  # - postgres-backup.yaml
 
 # namespace to deploy all Resources to
 namespace: predictivemovement-dev

--- a/k8s/base/stack/api.yaml
+++ b/k8s/base/stack/api.yaml
@@ -48,10 +48,10 @@ metadata:
 spec:
   tls:
     - hosts:
-        - pm-api.iteamdev.io
+        - api-dev.predictivemovement.se
       secretName: api-prod-tls
   rules:
-    - host: pm-api.iteamdev.io
+    - host: api-dev.predictivemovement.se
       http:
         paths:
           - backend:

--- a/k8s/base/stack/kustomization.yaml
+++ b/k8s/base/stack/kustomization.yaml
@@ -4,17 +4,17 @@ kind: Kustomization
 
 # list of Resource Config to be Applied
 resources:
-  - driver-interface.yaml
+  # - driver-interface.yaml
   - engine.yaml
-  - engine-server.yaml
-  - engine-ui.yaml
+  # - engine-server.yaml
+  # - engine-ui.yaml
   - route-optimization-jsprit.yaml
-  - vehicle-offer.yaml
-  - auto-accept-offer.yaml
-  - booking-dispatcher.yaml
-  - signing-ui.yaml
-  - extract-text-from-pic.yaml
-  - booking-interface.yaml
+  # - vehicle-offer.yaml
+  # - auto-accept-offer.yaml
+  # - booking-dispatcher.yaml
+  # - signing-ui.yaml
+  # - extract-text-from-pic.yaml
+  # - booking-interface.yaml
   - api.yaml
 
 # namespace to deploy all Resources to

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -4,39 +4,35 @@ metadata:
   name: pm-mapbox-test
 build:
   artifacts:
-    - image: iteam1337/pm-booking-interface # Disabled until needed again since we use the admin-ui for creating bookings
-      context: packages/booking-interface
-    - image: iteam1337/pm-driver-interface
-      context: packages/driver-interface
+    # - image: iteam1337/pm-booking-interface # Disabled until needed again since we use the admin-ui for creating bookings
+    #   context: packages/booking-interface
+    # - image: iteam1337/pm-driver-interface
+    #   context: packages/driver-interface
     - image: iteam1337/pm-engine
       context: packages/engine_umbrella
-      sync:
-        infer:
-          - "**/*.ex"
-          - "**/*.exs"
-    - image: iteam1337/pm-engine-server
-      context: packages/engine-server
-    - image: iteam1337/pm-engine-ui
-      context: packages/engine-ui
-      docker:
-        buildArgs:
-          REACT_APP_MAPBOX_ACCESS_TOKEN: "{{.REACT_APP_MAPBOX_ACCESS_TOKEN}}"
-          REACT_APP_ENGINE_SERVER: "{{.REACT_APP_ENGINE_SERVER}}"
+    # - image: iteam1337/pm-engine-server
+    #   context: packages/engine-server
+    # - image: iteam1337/pm-engine-ui
+    #   context: packages/engine-ui
+    #   docker:
+    #     buildArgs:
+    #       REACT_APP_MAPBOX_ACCESS_TOKEN: "{{.REACT_APP_MAPBOX_ACCESS_TOKEN}}"
+    #       REACT_APP_ENGINE_SERVER: "{{.REACT_APP_ENGINE_SERVER}}"
     - image: iteam1337/pm-route-optimization-jsprit
       context: packages/route-optimization-jsprit
-    - image: iteam1337/pm-vehicle-offer
-      context: packages/vehicle-offer
-    - image: iteam1337/pm-auto-accept-offer
-      context: packages/auto-accept-offer
-    - image: iteam1337/pm-booking-dispatcher
-      context: packages/booking-dispatcher
-    - image: iteam1337/pm-signing-ui
-      context: packages/signing-ui
-      docker:
-        buildArgs:
-          REACT_APP_ENGINE_SERVER: "{{.REACT_APP_ENGINE_SERVER}}"
-    - image: iteam1337/pm-extract-text-from-pic
-      context: packages/extract-text-from-pic
+    # - image: iteam1337/pm-vehicle-offer
+    #   context: packages/vehicle-offer
+    # - image: iteam1337/pm-auto-accept-offer
+    #   context: packages/auto-accept-offer
+    # - image: iteam1337/pm-booking-dispatcher
+    #   context: packages/booking-dispatcher
+    # - image: iteam1337/pm-signing-ui
+    #   context: packages/signing-ui
+    #   docker:
+    #     buildArgs:
+    #       REACT_APP_ENGINE_SERVER: "{{.REACT_APP_ENGINE_SERVER}}"
+    # - image: iteam1337/pm-extract-text-from-pic
+    #   context: packages/extract-text-from-pic
     - image: iteam1337/pm-api
       context: packages/api
 deploy:


### PR DESCRIPTION
Removed unneeded services. 
Added new namespace called `predictivemovement-dev` 
The api is live at https://api-dev.predictivemovement.se/
And the docs are here https://api-dev.predictivemovement.se/docs